### PR TITLE
Fix redirect after login

### DIFF
--- a/assets/js/api/errorHandler.js
+++ b/assets/js/api/errorHandler.js
@@ -1,7 +1,7 @@
 
 export default function (error) {
     if (error.response.status === 401) {
-        document.location.href='/login';
+        document.location.href='/login' + document.location.hash;
     }
 
     return Promise.reject(error);

--- a/src/Security/FormAuthenticator.php
+++ b/src/Security/FormAuthenticator.php
@@ -82,10 +82,6 @@ class FormAuthenticator extends AbstractFormLoginAuthenticator
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
     {
-        if ($targetPath = $this->getTargetPath($request->getSession(), $providerKey)) {
-            return new RedirectResponse($targetPath);
-        }
-
         return new RedirectResponse($this->router->generate('home'));
     }
 


### PR DESCRIPTION
When the user is disconnected due to his session being out of date, his reconnection displays him a json instead of the web interface. This is because after the login, Symfony sends it back to the last called url, which is an API request.

This patch redirect the user to the last used VueJs route.