### PR TITLE
Fix download chart

### DIFF
--- a/src/Controller/Api/DownloadsController.php
+++ b/src/Controller/Api/DownloadsController.php
@@ -43,6 +43,8 @@ class DownloadsController extends AbstractController
             $data[$item['date']]['version'] = $item['downloads'];
         }
 
+        ksort($data);
+
         return $this->json($data);
     }
 }


### PR DESCRIPTION
Hi @julienj !

The download graph is currently a little messy like you can see on this picture : 

![bugged-chart](https://user-images.githubusercontent.com/6725138/64606966-cc3ccc80-d3c7-11e9-9c2e-330f4939685f.png)

The reason is that the plugin join the point as he read them in the data and that way does not follow the true chronology if the data are not ordered.

That's why this little PR add a ksort on the API to get a more conventional graph :

![fixed-chart](https://user-images.githubusercontent.com/6725138/64607005-e24a8d00-d3c7-11e9-9327-332c66810841.png)

